### PR TITLE
Add EventLoopThread.get_loop method

### DIFF
--- a/asyncx/thread.py
+++ b/asyncx/thread.py
@@ -99,7 +99,7 @@ class EventLoopThread(threading.Thread):
         if loop is None:
             raise RuntimeError("Thread is not running")
 
-        return self.loop
+        return loop
 
     @property
     def loop(self) -> asyncio.AbstractEventLoop:

--- a/asyncx/thread.py
+++ b/asyncx/thread.py
@@ -86,17 +86,28 @@ class EventLoopThread(threading.Thread):
         finally:
             self._loop = None
 
-    @property
-    def loop(self) -> asyncio.AbstractEventLoop:
+    def get_loop(self) -> asyncio.AbstractEventLoop:
         """Get an event loop of the running thread.
 
-        The thread should be running. The method will raise :class:`RuntimeError`
+        The thread must be running. The method will raise :class:`RuntimeError`
         if the thread is not running.
+
+        See also:
+            Use :attr:`EventLoopThread.loop` if you need an accessor to the loop.
         """
         loop = self._loop
         if loop is None:
             raise RuntimeError("Thread is not running")
-        return loop
+
+        return self.loop
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        """Get an event loop of the running thread.
+
+        The property just returns the return value of :func:`EventLoopThread.get_loop`.
+        """
+        return self.get_loop()
 
     def start(self) -> None:
         """Start the thread and wait for a new event loop to be ready.

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -28,6 +28,9 @@ async def test_event_loop_thread(event_loop_thread: asyncx.EventLoopThread) -> N
     with pytest.raises(RuntimeError):
         event_loop_thread.loop
 
+    with pytest.raises(RuntimeError):
+        event_loop_thread.get_loop()
+
     coro = _get_ident()
     with pytest.raises(RuntimeError):
         event_loop_thread.run_coroutine(coro)
@@ -35,6 +38,7 @@ async def test_event_loop_thread(event_loop_thread: asyncx.EventLoopThread) -> N
 
     event_loop_thread.start()
     assert event_loop_thread.is_alive()
+    assert event_loop_thread.get_loop() is not None
     assert event_loop_thread.loop is not None
     main, sub = await asyncio.gather(
         _get_ident(),
@@ -50,6 +54,9 @@ async def test_event_loop_thread(event_loop_thread: asyncx.EventLoopThread) -> N
 
     with pytest.raises(RuntimeError):
         event_loop_thread.loop
+
+    with pytest.raises(RuntimeError):
+        event_loop_thread.get_loop()
 
     coro = _get_ident()
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
The function style (i.e.`EventLoopThread.get_loop`) would be useful for using `asyncx.dispatch` with the `EventLoopThread`.