### PR TITLE
Use asyncio.get_running_loop in dispatch

### DIFF
--- a/asyncx/event_loop.py
+++ b/asyncx/event_loop.py
@@ -46,7 +46,7 @@ def dispatch(
 
             coro = func(*args, **kwargs)
 
-            caller_loop = asyncio.get_event_loop()
+            caller_loop = asyncio.get_running_loop()
             if caller_loop == target_loop:
                 return await coro
             else:


### PR DESCRIPTION
`get_event_loop` implicitly creates an event loop if it doesn't exist.
`dispatch` should not use the method and it should raise an error instead.