### PR TITLE
Only accept an async function in asyncx.dispatch

### DIFF
--- a/asyncx/_types.py
+++ b/asyncx/_types.py
@@ -1,0 +1,10 @@
+import asyncio
+from typing import Any, Callable, Coroutine, TypeVar, Union
+
+TAsyncCallable = TypeVar(
+    "TAsyncCallable", bound=Callable[..., Coroutine[Any, Any, Any]]
+)
+EventLoopSelector = Union[
+    asyncio.AbstractEventLoop,
+    Callable[[], asyncio.AbstractEventLoop],
+]

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -4,39 +4,34 @@ import threading
 import pytest
 
 import asyncx
+from asyncx._types import EventLoopSelector
+
+
+async def _test_dispatch(selector: EventLoopSelector) -> None:
+    async def func() -> int:
+        await asyncio.sleep(0.01)
+        return threading.get_ident()
+
+    @asyncx.dispatch(selector)
+    async def func_dispatch_standard() -> int:
+        return await func()
+
+    @asyncx.dispatch(selector)
+    async def func_dispatch_no_await() -> int:
+        return threading.get_ident()
+
+    base, dispatched = await asyncio.gather(
+        func(),
+        func_dispatch_standard(),
+    )
+    assert base != dispatched
+    assert dispatched == await func_dispatch_no_await()
 
 
 @pytest.mark.asyncio
 async def test_dispatch() -> None:
     with asyncx.EventLoopThread() as thread:
-
-        async def func() -> int:
-            await asyncio.sleep(0.01)
-            return threading.get_ident()
-
-        @asyncx.dispatch(thread.loop)
-        async def func_dispatch() -> int:
-            return await func()
-
-        main, sub = await asyncio.gather(func(), func_dispatch())
-
-    assert main != sub
-
-
-@pytest.mark.asyncio
-async def test_dispatch_callable() -> None:
-    def get_event_loop() -> asyncio.AbstractEventLoop:
-        return thread.loop
-
-    async def func() -> int:
-        await asyncio.sleep(0.01)
-        return threading.get_ident()
-
-    @asyncx.dispatch(get_event_loop)
-    async def func_dispatch() -> int:
-        return await func()
+        await _test_dispatch(thread.loop)
 
     with asyncx.EventLoopThread() as thread:
-        main, sub = await asyncio.gather(func(), func_dispatch())
-
-    assert main != sub
+        await _test_dispatch(thread.get_loop)


### PR DESCRIPTION
The current type annotation of `asyncx.dispatch` accepts not only an async function (i.e. a function that returns a coroutine object) but also a function that returns an awaitable object.

But, this is a bit confusing and can lead to misunderstanding:
```py
def foo() -> int:
    return threading.get_ident()

@asyncx.dispatch(loop)
async def foo_this_is_dispatched() -> int:
    ident = foo()
    return asyncx.just(ident)


@asyncx.dispatch(loop)
def foo_actually_not_dispatched() -> Awaitable[int]:
    ident = foo()
    return asyncx.just(ident)

assert await foo() != await foo_this_is_dispatched()
assert await foo() == await foo_actually_not_dispatched
```

Thus, I would like to limit the target functions of `asyncx.dispatch` to async functions.